### PR TITLE
Fix compile problems in OMeterWorker

### DIFF
--- a/src/OMeterWorker.cpp
+++ b/src/OMeterWorker.cpp
@@ -128,7 +128,7 @@ const int OMeterWorker::new_osc_client(lo_message client) {
 }
 
 
-const int OMeterWorker::osc_client_exists(lo_address client) {
+const int OMeterWorker::osc_client_exists(lo_message client) {
     int i;
     int ret = -1;
     char* new_client_url = lo_address_get_url(lo_message_get_source(client));
@@ -170,7 +170,7 @@ void OMeterWorker::send_osc_all(const char* path, lo_message msg)  {
 	
 	for( int i = 0; i < MAX_OSC_CLIENTS; i++) {
 		if( osc_client[i] )
-			lo_send_message_from(osc_client[i], osc_server, path, msg);
+			lo_send_message_from(osc_client[i], osc_server_out, path, msg);
 	}
 	
 }

--- a/src/OMeterWorker.h
+++ b/src/OMeterWorker.h
@@ -51,9 +51,9 @@ public:
 #ifdef HAVE_OSC
     lo_address osc_client[MAX_OSC_CLIENTS];
     lo_server_thread osc_server;
-    lo_address osc_server_out;
+    lo_server osc_server_out;
     const int new_osc_client(lo_message client);
-    const int osc_client_exists(lo_address client);
+    const int osc_client_exists(lo_message client);
     void send_osc(int client_index, const char* path, lo_message msg);
     void send_osc_all(const char* path, lo_message msg);
     void dump_message(const char* path, const char *types, lo_arg ** argv, int argc);


### PR DESCRIPTION
I had some problems when installing your nice tool (I used it with great fun in Debian buster) for Debian bullseye.
So I fixed three slight issues and now it runs again on my machine.
Nevertheless I am still wondering, why previous compiler runs did not complain ... The compiler version I used is g++ (Debian 10.2.1-6) 10.2.1 20210110.
One precondition for tascal-gtk is package liblo, which was not available in Debian bullseye, so I installed it manually from https://github.com/radarsat1/liblo as liblo.so.7.4.1. I am not sure whether this caused my problems with the tascal-gtk project.

Please check whether the fix makes sense for your project.

Kind regards